### PR TITLE
fix UnicodeDecodeError error

### DIFF
--- a/telespeechasr/onnx/onnx_infer.py
+++ b/telespeechasr/onnx/onnx_infer.py
@@ -123,7 +123,7 @@ class TeleSpeechAsrInferSession:
             os.path.dirname(__file__), "data", "vocab.json"
         )
 
-        with open(self.vocab_path, "r") as f:
+        with open(self.vocab_path, "r", encoding='utf-8') as f:
             self.vocab2id = json.load(f)
             self.id2vocab = {}
             for k, v in self.vocab2id.items():


### PR DESCRIPTION
因为vocab json是中文的 需要修改读取方式，否则在某些环境会读取为gbk，从而导致json loads error